### PR TITLE
FEAT: API key 반환을 위한 config.py 파일 추가

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,24 @@
+from dotenv import load_dotenv
+import os
+from typing import Optional
+
+load_dotenv()  # .env 파일 로드
+
+# Gemini API 설정
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+# Supabase 설정
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
+
+def get_gemini_api_key() -> str:
+    """Gemini API key를 반환합니다."""
+    if not GEMINI_API_KEY:
+        raise ValueError("GEMINI_API_KEY가 설정되지 않았습니다.")
+    return GEMINI_API_KEY
+
+def get_supabase_config() -> tuple[str, str]:
+    """Supabase 설정을 반환합니다."""
+    if not SUPABASE_URL or not SUPABASE_KEY:
+        raise ValueError("SUPABASE_URL 또는 SUPABASE_KEY가 설정되지 않았습니다.")
+    return SUPABASE_URL, SUPABASE_KEY


### PR DESCRIPTION
## 📝 작업 요약
API key 반환을 위해 config.py 파일을 추가했습니다. 

## 💡 상세 설명

  - 환경 변수 설정
  .env 에서 API key 를 읽어옵니다, .env 는 절대로 git에서 공유되어서는 안됩니다.
  
  - supabase URL, KEY 
  function get_supabase_config 에서 supabase 의 URL과 KEY 를 tuple 형태로 반환합니다.
  return SUPABASE_URL, SUPABASE_KEY -> tuple[SUPABASE_URL, SUPABASE_KEY]
  
  - GEMINI API key 
  function get_gemini_api_key 에서 GEMINI  key 를 string 형태로 반환합니다.
  return GEMINI_API_KEY